### PR TITLE
Js of ocaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+# the resulting working website is to be found in _build/html
+all:
+	ocamlbuild -use-ocamlfind \
+	  -tag debug \
+	  -plugin-tag "package(js_of_ocaml.ocamlbuild)" \
+	  -package js_of_ocaml.ppx \
+	  -package ppx_deriving_yojson \
+	  -no-links \
+	  html/index.html html/bind_gen.js
+
+clean:
+	ocamlbuild -clean

--- a/gen.ml
+++ b/gen.ml
@@ -1,0 +1,240 @@
+structure ComicGen =
+struct
+
+(* visual elements *)
+type ve = int
+
+(* a frame has a name and a number of holes *)
+type frame = {name:string, nholes:int}
+
+  val available_frames =
+    [
+      {name="whisper", nholes=2},
+      {name="monolog", nholes=1},
+      {name="dialog", nholes=2},
+      {name="touch", nholes=2},
+      {name="blank", nholes=0},
+      {name="walk", nholes=1},
+      {name="posse", nholes=4},
+      {name="carry", nholes=2},
+      {name="aid", nholes=2},
+      {name="fall", nholes=1}
+    ]
+
+type panel = {name:string, elements : ve list}
+
+datatype transition
+  = Moment | Add | Subtract | Meanwhile | RendezVous | End
+
+type comic = (panel * transition) list
+
+val rand = Random.rand(1,13123)
+
+  fun roll () =
+    case Random.randRange (1,6) rand of
+         1 => Moment
+       | 2 => Add
+       | 3 => Subtract
+       | 4 => Meanwhile 
+       | 5 => RendezVous
+       | _ => End
+
+  fun roll_continue () =
+    case roll () of 
+         End => roll_continue ()
+       | other => other
+
+  fun randElt l =
+    List.nth (l, Random.randRange (0, (List.length l) - 1) rand)
+
+  fun randSplit l =
+  let
+    val idx = Random.randRange (0, List.length l - 1) rand
+    fun split [] target prefix idx = raise Subscript
+      | split (x::xs) target prefix idx =
+            if target = idx then ((rev prefix)@xs, x)
+            else split xs target (x::prefix) (idx+1)
+  in
+    split l idx [] 0
+  end
+
+  fun hasAtLeastNHoles n {name, nholes} = nholes >= n
+  fun hasAtMostNHoles n {name, nholes} = nholes <= n
+
+  fun pickRandomFrame () =
+    randElt available_frames
+
+  fun pickFrame nVEs =
+    randElt (List.filter (hasAtMostNHoles nVEs) available_frames)
+
+  fun genElts n = List.tabulate (n, fn i => i +1)
+  fun newElt n = n+1
+
+  fun decideNew unused =
+    if List.length unused = 0 then true (* make up new if unused is empty *)
+    else
+      case Random.randRange (0,2) rand of
+           0 => true
+         | _ => false (* bias toward using previous chars *)
+
+  fun pickRandomVEs' unused n acc counter =
+    if n = 0 then (acc, counter)
+    else if not (decideNew unused) then
+           (* choose a previously-appearing character *)
+              let
+                val (unused, elt) = randSplit unused
+              in
+                pickRandomVEs' unused (n-1) (elt::acc) counter
+              end
+           (* choose a new character *)
+         else pickRandomVEs' unused (n-1) ((newElt counter)::acc) (counter+1)
+
+  fun pickRandomVEs unused n counter =
+    pickRandomVEs' unused n [] counter
+
+  fun removeRandom l =
+  let
+    val elt = randElt l
+  in
+    List.filter (fn x => not (x = elt)) l
+  end
+
+  (*
+  (* XXX eventually care about transition type *)
+  fun pickVEs n allPriorVEs (t:transition) (({name,elements},_)::_ : comic) =
+  let
+    val totalNVEs = List.length allPriorVEs
+  in
+      case t of
+           Moment => (elements, totalNVEs)
+         | Add => (elements, totalNVEs) (* XXX *)
+         | Subtract => 
+             if List.length elements > 0 
+             then (removeRandom elements, totalNVEs)
+             else (elements, totalNVEs)
+         | Meanwhile => 
+             (* XXX eventually exclude current VEs *)
+             pickRandomVEs allPriorVEs n totalNVEs
+         | RendezVous => (* (randElt available_ves)::elements *)
+           (* XXX maybe this should also choose the frame? *)
+             pickRandomVEs allPriorVEs n totalNVEs
+         | End => ([], totalNVEs)
+  end
+  *)
+
+  fun listMember x [] = false
+    | listMember x (y::ys) = x = y orelse listMember x ys
+
+  fun nonmembers l l' = List.filter (fn x => not (listMember x l)) l'
+
+  fun pickPanel allPrior (current_panel : panel) transition
+    : panel * int =
+    let
+      val justPrior = #elements current_panel
+      val currentNVEs = List.length justPrior
+      val totalNVEs = List.length allPrior
+    in
+      case transition of
+           Moment =>
+           let
+             val {name, nholes} = pickFrame currentNVEs
+           in
+             ({name=name, elements=justPrior}, totalNVEs) 
+           end
+         | Add =>
+           let
+             val unused = nonmembers justPrior allPrior
+             val howManyNew = 1 (* Random.randRange (1,2) rand *)
+             val {name, nholes} = pickFrame (currentNVEs + howManyNew)
+             val (new_elts, new_total) = pickRandomVEs unused howManyNew totalNVEs
+             val new_elts = new_elts @ justPrior
+           in
+             ({name=name, elements=new_elts}, new_total) 
+           end
+         | Subtract =>
+             if List.length justPrior > 0 then
+              let
+                val nVEs = currentNVEs - 1
+                val {name, nholes} = pickFrame nVEs
+                val elts = removeRandom justPrior
+              in
+                ({name=name, elements=elts}, totalNVEs)
+              end
+            else
+              let
+                val {name, nholes} = pickFrame 0
+              in
+                ({name=name, elements=[]}, totalNVEs)
+              end
+         | Meanwhile =>
+             let
+               val skipVEs = nonmembers justPrior allPrior
+               val {name, nholes} = pickRandomFrame ()
+               val (elts, newTotal) = pickRandomVEs skipVEs nholes totalNVEs
+             in
+               ({name=name, elements=elts}, newTotal)
+             end
+         | RendezVous =>
+             let
+               val {name, nholes} = pickRandomFrame ()
+               val (elts, newTotal) = pickRandomVEs allPrior nholes totalNVEs
+             in
+               ({name=name, elements=elts}, newTotal)
+             end
+         | End => ({name="blank", elements=[]}, totalNVEs)
+    end
+
+  fun fillFrame ({name,nholes}: frame) (VEs : ve list) : panel =
+    {name=name, elements=VEs}
+
+  fun gen (soFar:comic) (nves : int) min max : comic =
+    case soFar of
+         [] => 
+         let 
+           val new_frame = pickFrame nves
+           val VEs = genElts nves
+           val panel = fillFrame new_frame VEs
+           val transition = roll_continue ()
+         in
+           gen [(panel, transition)] nves min max
+         end
+       | ((current_panel, transition)::more) =>
+           let
+             val current_length = List.length soFar
+             val next_transition = 
+               if current_length >= max then End
+               else
+                if current_length < min
+                then roll_continue () 
+                else roll ()
+           in
+             case transition of
+                  End => rev soFar
+                | tr =>
+                    let
+                      val allPrior = genElts nves
+                      val (panel, newTotal) = 
+                        pickPanel allPrior current_panel transition
+                    in
+                      gen ((panel, next_transition)::soFar) newTotal min max
+                    end
+
+                    (*
+                      val currentNVEs = List.length justPrior
+                      val {name=cname, elements=ves} = current_panel
+                      val {name=fname, nholes} = pickRandomFrame () (* XXX *) 
+                      val (new_ves, new_total) = pickVEs nholes allPrior tr soFar
+                      val panel = fillFrame {name=fname, nholes=nholes} new_ves
+                    in
+                      gen ((panel, next_transition)::soFar) new_total
+                    end
+                    *)
+
+           end
+
+  (* Next steps:
+  * - Impose a limit on the number of entities introduced?
+  * - port to JS and do image generation?
+  *)
+
+end

--- a/gen.ml
+++ b/gen.ml
@@ -1,8 +1,10 @@
 (* visual elements *)
 type ve = int
+  [@@deriving yojson]
 
 (* a frame has a name and a number of holes *)
 type frame = {name: string; nholes:int}
+  [@@deriving yojson]
 
   let available_frames =
     [
@@ -19,11 +21,14 @@ type frame = {name: string; nholes:int}
     ]
 
 type panel = {name:string; elements : ve list}
+  [@@deriving yojson]
 
 type transition
   = Moment | Add | Subtract | Meanwhile | RendezVous | End
+  [@@deriving yojson]
 
 type comic = (panel * transition) list
+  [@@deriving yojson]
 
   (* initialize the random number generator *)
   let () = Random.full_init [|1; 13123|]

--- a/html/bind_gen.ml
+++ b/html/bind_gen.ml
@@ -1,0 +1,7 @@
+let () =
+  Js.Unsafe.global##.comic := object%js
+    method gen nves min max =
+      Printf.eprintf "Call: nves=%d; min=%d; max=%d\n%!" nves min max;
+      let comic = Gen.gen [] nves min max in
+      Js.string (Yojson.Safe.pretty_to_string (Gen.comic_to_yojson comic))
+  end

--- a/html/index.html
+++ b/html/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>js_of_ocaml example</title>
+    <script type="text/javascript" src="./bind_gen.js"></script>
+    <script type="text/javascript">
+      function add_comic_JSON(){
+        nves = parseInt(document.getElementById('NVEs').value);
+        min = parseInt(document.getElementById('min').value);
+        max = parseInt(document.getElementById('max').value);
+
+        document.getElementById('output').innerHTML =
+          comic.gen(nves, min, max);
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Comics generator</h1>
+    <p>This is just a very raw interface
+    to <a href="https://github.com/chrisamaphone/comicgen/">this
+    code</a>,
+    see <a href="http://lambdamaphone.blogspot.fr/2015/12/generativity-interpretation-study-of.html">this
+    blog post</a> for details.</p>
+
+
+    <form>
+      Number of Visual Elements (NVEs): <input type="text" value="4" id="NVEs"/><br/>
+      Min: <input type="text" value="10" id="min"/><br/>
+      Max: <input type="text" value="20" id="max"/><br/>
+    </form>
+
+    <p><a href="#" onClick="add_comic_JSON();">Click to generate stuff</a></p>
+    <pre id="output"></pre>
+  </body>
+</html>

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -1,0 +1,1 @@
+let _ = Ocamlbuild_plugin.dispatch Ocamlbuild_js_of_ocaml.dispatcher


### PR DESCRIPTION
I saw in the [blog post](http://lambdamaphone.blogspot.fr/2015/12/generativity-interpretation-study-of.html) that you were interested in a JS port of the codebase, to render generated comics in a browser. I tried to use [js_of_ocaml](http://ocsigen.org/js_of_ocaml/) for that purpose, a compiler from OCaml to javascript.

The first commit just copies gen.sml unchanged (so that I can `git show --patience` the diff commit and look at the SML->OCaml changes), the second commit ports the code to OCaml, which is rather straightforward, and the third sets up a simplistic javascript compilation pipeline and a toy webpage to test it -- the OCaml-to-JS bridge in `html/bind_gen.ml` defines a function that takes `nves, min, max` in input and returns the JSON marshalling of the returned comic (as a string), so it should be very simple to develop pure-javascript display logic from that.

(It is also possible to write the rendering logic on the OCaml side as the js_of_ocaml project provides libraries to generate HTML, access the DOM and call arbitrary javascript libraries.)
